### PR TITLE
Improve geometry correction interface to Jython for Echidna

### DIFF
--- a/bragg/echidna/au.gov.ansto.bragg.echidna.dra/src/au/gov/ansto/bragg/echidna/dra/core/GeometryCorrection.java
+++ b/bragg/echidna/au.gov.ansto.bragg.echidna.dra/src/au/gov/ansto/bragg/echidna/dra/core/GeometryCorrection.java
@@ -148,9 +148,12 @@ public class GeometryCorrection extends ConcreteProcessor {
 	 * @param Zpvertic  Offset in z position at each 2-theta value
 	 * @param contribs  Pixel ok map
 	 * @param radius Curved detector radius
+	 * @param bottom bottom-most pixel position to consider
+	 * @param top top-most pixel position to consider
 	 */
 	public void correctGeometry(IArray iSample, IArray raw_theta, double radius, IArray thetaVect, IArray Zpvertic, IArray variance,
-			/* output */
+								int bottom, int top,
+								/* output */
 			                    IArray contribs, IArray decurved_data, IArray decurved_variance)
 	{   		
 		int verPixels = iSample.getShape()[0];
@@ -205,7 +208,7 @@ public class GeometryCorrection extends ConcreteProcessor {
 		{
 			double inTheta = 	raw_theta.getDouble(rawthind.set(i)) * (Math.PI)/180; // convert to radians
 			double oldcos = Math.cos(inTheta);  //precalculate for efficiency
-			for(int j = 0; j < verPixels; j++)
+			for(int j = bottom; j < top; j++)
 			{
 				if (Zpvertic != null) invz = Zpvertic.getDouble(zpind.set(j)); //vertical offset for this vertical pixel coordinate
 				double xFactor = radius/Math.sqrt(radsq+invz*invz);

--- a/bragg/echidna/au.gov.ansto.bragg.echidna.dra/src/au/gov/ansto/bragg/echidna/dra/core/GeometryCorrection.java
+++ b/bragg/echidna/au.gov.ansto.bragg.echidna.dra/src/au/gov/ansto/bragg/echidna/dra/core/GeometryCorrection.java
@@ -282,6 +282,178 @@ public class GeometryCorrection extends ConcreteProcessor {
 		System.out.printf("Nonzero pixels in mask: %d%n",nonzero);
 	}
 
+	 /* Apply geometry correction for HRPD curved detector onto an even 2-theta grid. An even grid is reasonable
+	  * given that the only points for which an uneven grid will produce exact results are those on the 
+	  * equatorial plane.
+	 * This method will set the return data and variance
+	 * Java arrays, as well as a region array describing which parts of the return array can be included in any
+	 * horizontal integration.
+	 * 
+	 * This routine has been adjusted so it can be directly called from Python after instantiating this class. It
+	 * will no longer work as part of the old Java-based data reduction routines.
+	 * 
+	 * This version of the routine uses interpolation instead of reassignment.
+	 * 
+	 * @param iSample  input 2D array data set after stitching (nTubes*nScan)*yPixels
+	 * @param stepsize ideal stepsize to use when building output two-theta array 
+	 * @param thetaVect   OneD array theta vector in degrees
+	 * @param Zpvertic  Offset in z position at each 2-theta value
+	 * @param contribs  Pixel ok map
+	 * @param radius Curved detector radius
+	 * @param bottom bottom-most pixel position to consider
+	 * @param top top-most pixel position to consider
+	 */
+	public void correctGeometryInterp(IArray iSample, IArray raw_theta, double radius, IArray thetaVect, IArray Zpvertic, IArray variance,
+								int bottom, int top,
+								/* output */
+			                    IArray contribs, IArray decurved_data, IArray decurved_variance)
+	{   		
+		int verPixels = iSample.getShape()[0];
+		int horiPixels = iSample.getShape()[1];
+		long thlen = thetaVect.getSize();
+
+		int mNewPixels = 0;
+		double cor2theta = 0.0;    // corrected value
+		double invz =0.0;
+		
+		IIndex thind = thetaVect.getIndex();
+		IIndex rawthind = raw_theta.getIndex();
+		
+		double inTheta0 = thetaVect.getDouble(thind.set(0)) * (Math.PI)/180; //start angle, radians
+		long mScanxPixels = thlen;
+		double mdtheta = (thetaVect.getDouble(thind.set((int) (thlen-1))) - thetaVect.getDouble(thind.set(0)))/(thlen - 1) * (Math.PI/180);
+		System.out.println("Theta step is " +mdtheta);
+		
+		/* our strategy is to interpolate to predict the true two-theta value of each pixel, and insert the 
+		 * interpolated intensity
+		 * into our array of (y, true 2-theta)-indexed intensities. Note
+		 * that the Jacobian of our transformation is in this case simply
+		 * d 2theta_new/d 2theta (as the derivatives with respect to pixel height are 0 and 1 respectively)
+		 * which is
+		 * 1/sqrt(1-cos^2 2theta_new) * sin 2theta
+		 * 
+		 * Note that at 2theta = 90 this is 1 everywhere, as it is for vertical offset = 0
+		 * 
+		 * The efficiency correction (which is more correctly a flood field correction)
+		 * will have corrected for the geometrical effect of smaller solid angle per pixel
+		 * away from the equatorial plane, in that the flood field data will be weaker and thus produce a 
+		 * larger efficiency value.  They will be weaker by a factor of the Jacobian, so multiplication
+		 * by the Jacobian should not be necessary.
+		 */
+
+		double radsq = radius*radius;   //precalculate for efficiency
+		
+		IIndex isind = iSample.getIndex();
+		IIndex varind = variance.getIndex();
+		IIndex zpind = Zpvertic.getIndex();
+		IIndex contind = contribs.getIndex();
+		IIndex decind = decurved_data.getIndex();
+		IIndex decvarind = decurved_variance.getIndex();
+		
+		float[][] ncontr = new float[verPixels][(int) thlen];
+		
+		for(int j = bottom; j < top; j++) { // interpolation runs horizontally 
+
+			invz = Zpvertic.getDouble(zpind.set(j)); //vertical offset for this vertical pixel coordinate
+			double xFactor = radius/Math.sqrt(radsq+invz*invz);
+
+			for(int i = 0; i < horiPixels; i++) {  //loop over raw two theta grid
+					double inTheta = 	raw_theta.getDouble(rawthind.set(i)) * (Math.PI)/180; // convert to radiansraw
+					double oldcos = Math.cos(inTheta);
+					cor2theta = Math.acos(xFactor*oldcos);    //potential sign issues?
+					// find out where this pixel would sit on the transformed grid.
+					double grid_pos = (cor2theta-inTheta0)/mdtheta;
+					mNewPixels = (int) Math.round(grid_pos);
+					double ideal_pos = inTheta0 + mNewPixels * mdtheta;
+					
+					// proportion of intensity to assign
+					
+					double shift = (cor2theta - ideal_pos)/mdtheta;
+					
+					/* Use offset as a proxy for proportion of the pixel to move. If shift is positive, the ideal position is to the right
+					 * and the next pixel right will get shift*intensity added to it. If shift is negative, the ideal position is back to
+					 * the left of centre and that position will get abs(shift)* intensity added to it. In both cases the ideal pixel gets
+					 * the remainder of the intensity. 
+					 */
+					int partial = (int) (mNewPixels + Math.signum(shift));
+					shift = Math.abs(shift);
+					ncontr[j][mNewPixels]+=(1-shift);
+					decind.set(j, mNewPixels);
+					decvarind.set(j, mNewPixels);
+					isind.set(j,i); varind.set(j,i);
+					decurved_data.setDouble(decind, decurved_data.getDouble(decind) + iSample.getDouble(isind) * (1-shift));
+					decurved_variance.setDouble(decvarind, decurved_variance.getDouble(decvarind) + variance.getDouble(varind) * (1-shift));
+					
+					/* Add in remaining intensity */
+					
+					if (partial >= 0 && partial < thlen) {
+					    ncontr[j][partial] += shift;
+					    decind.set(j, partial);
+					    decvarind.set(j, partial);
+					    decurved_data.setDouble(decind, decurved_data.getDouble(decind) + iSample.getDouble(isind) * shift);
+					    decurved_variance.setDouble(decvarind, decurved_variance.getDouble(decvarind) + variance.getDouble(varind) * shift);
+					}
+			}
+		}
+
+		/* When this dataset is vertically integrated, we need to avoid accessing the regions that were
+		 not accessible to the cylindrical detector but after straightening transformation are now included
+		 in the output array.  We thus create a 'mask' array with 0 in non-contributor positions and '1' in
+		 contributor positions. To avoid edge
+		 effects we throw away data within one pixel of the boundaries.  The following heuristic may fail for pathological
+		 cases, for example when only two adjacent vertical pixels are contributors: the first is detected,
+		 and the second is skipped over.  Note that we do not normalise by the number of contributions: the
+		 efficiency (or more properly flood-field) correction has taken care of the compression effects already.
+		 */
+		
+		int nonzero = 0; // count nonzero pixels
+		float maxcontribs = 0; //find maximum squash
+		for(int i=0;i<mScanxPixels;i++)
+		{
+		//	System.out.printf("%d: ",i);
+			for(int j=1;j<verPixels-1;j++) {
+				/* look for the edges */
+				if (ncontr[j][i] > maxcontribs) { 
+					maxcontribs = ncontr[j][i]; 
+					}
+				contind.set(j, i);
+				if (ncontr[j][i] > 0 && ncontr[j-1][i] > 0 && ncontr[j+1][i]>0) {
+					contribs.setInt(contind,1);
+					nonzero++;
+					continue;
+				}
+				if (ncontr[j][i] > 0 && ncontr[j-1][i] == 0) {  // found a rising edge, discard this value
+					decind.set(j,i);
+					decvarind.set(j,i);
+					decurved_data.setDouble(decind,0.0);
+					decurved_variance.setDouble(decvarind, 0.0);
+					j++;
+					contind.set(j,i);                           // skip the new real edge value
+					contribs.setInt(contind,1);                          // but it does contribute
+					nonzero++;
+					continue;                                   
+				}
+				if (ncontr[j][i] == 0 && ncontr[j-1][i] > 0) {   // a falling edge
+					decind.set(j-1,i);
+					decvarind.set(j-1,i);					
+					decurved_data.setDouble(decind,0.0);
+					decurved_variance.setDouble(decvarind,0.0);
+				}
+			}
+			/* Handle the vertical edges */
+			if (ncontr[0][i]>0) {
+				contind.set(0,1);
+				contribs.setInt(contind, 1); nonzero++;
+			}
+			if (ncontr[verPixels-1][i]>0) {
+				contind.set(verPixels-1, i);
+				contribs.setInt(contind, 1); nonzero++;
+				}
+		}
+		System.out.printf("Maximum contributors to a pixel %f%n", maxcontribs);
+		System.out.printf("Nonzero pixels in mask: %d%n",nonzero);
+	}
+
 	public IGroup getGeometryCorrection_output() {
 		return geometryCorrection_output;
 	}


### PR DESCRIPTION
Adjustments to the GeometryCorrection class for Echidna to enable easier calling from Jython.

1. Stitched data from overlapping scans can be provided
2. The ideal 2-theta grid is now provided externally (by Jython)
3. Two alternative straightening algorithms are included
4. Array structures provided by the caller to return the results